### PR TITLE
New UI + slippery mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,12 @@ This version features several fixes and improvements over Marum's original versi
 - Full duplicator/advdupe2 support, no more broken hoverballs after duping a contraption.
 - Added hotkeys to smoothly increase/decrease hover height, toggle hovering on and off, etc.
 - Added an airbrake function to slow down your vehicles without relying on thrusters.
-- Offset hoverballs spawn facing the hitnormal of the tool trace, instead of always spawning pointing up.
-- Hoverballs now show info when looking at them.
+- Experimental 'Slippery mode' allows your vehicles to slide down slopes. Make a hover-sled!
+- Sleek-ish UI that shows info when looking at a hoverball.
 - Can now click existing hoverballs to update their values without having to remove and replace them.
-- More models to choose from.
+- Update settings on a whole contraption in one go with ALT + Left click.
+- Configuration options for everything you could want, and probably even some stuff you didn't.
+- Lasers! Everybody loves lasers.
 - More that can be found on the Steam workshop page: https://steamcommunity.com/sharedfiles/filedetails/?id=2502939629
 
 # How to install:

--- a/lua/entities/offset_hoverball/cl_init.lua
+++ b/lua/entities/offset_hoverball/cl_init.lua
@@ -1,6 +1,129 @@
 include("shared.lua")
 
+local laser = Material("sprites/bluelaser1")
+local ShouldRenderLasers = GetConVar("offset_hoverball_showlasers")
+local ShouldAlwaysRenderLasers = GetConVar("offset_hoverball_alwaysshowlasers")
+local ToolMode = GetConVar("gmod_toolmode")
+
+-- Baed on garrysmod/lua/derma/init.lua it looks like the game comes with the Roboto font, so it should be safe to use on all platforms?
+surface.CreateFont( "OHBTipFont", {
+	font = "Roboto Regular",
+	size = 24,
+	weight = 13,
+	blursize = 0,
+	scanlines = 0,
+	antialias = true,
+	extended = true,
+} )
+
+surface.CreateFont( "OHBTipFontGlow", {
+	font = "Roboto Regular",
+	size = 24,
+	weight = 13,
+	scanlines = 0,
+	antialias = true,
+	extended = true,
+	blursize = 5,
+} )
+
+
+surface.CreateFont( "OHBTipFontSmall", {
+	font = "Roboto Regular",
+	size = 20,
+	weight = 13,
+	blursize = 0,
+	scanlines = 0,
+	antialias = true,
+	extended = true,
+} )
+
+
+function ENT:DrawLaser()
+	
+	if ShouldAlwaysRenderLasers:GetBool() or (LocalPlayer():GetActiveWeapon():GetClass() == "gmod_tool" and ToolMode:GetString() == "offset_hoverball") then
+
+		local hbpos = self:GetPos()
+		local function traceFilter(ent) if (ent:GetClass() == "prop_physics") then return false end end
+		local tr = util.TraceLine({
+			start  = hbpos,
+			output = output,
+			endpos = hbpos + Vector(0, 0, -500),
+			filter = traceFilter, mask = self.mask
+		});
+	
+		if tr.Hit then
+			cam.Start3D()
+				render.SetMaterial(laser)
+				render.DrawBeam(hbpos, tr.HitPos, 5, 0, 0, Color(100, 100, 255))
+				render.SetMaterial(Material("Sprites/light_glow02_add"))
+				render.DrawQuadEasy(tr.HitPos + Vector(0,0,1), tr.HitNormal, 30, 30, Color(100, 100, 255))
+				render.DrawQuadEasy(hbpos, (EyePos() - LocalPlayer():GetEyeTrace().HitPos):GetNormal(), 30, 30, Color(100, 100, 255))
+			cam.End3D()
+		end
+	end
+end
+
+local BoxOffsetX, BoxOffsetY = ScrW()/2+60, ScrH()/2-50
+
+hook.Add( "HUDPaint", "OffsetHoverballs_MouseoverUI", function()
+	local LookingAt = LocalPlayer():GetEyeTrace().Entity
+	local BoxScaleX = 160
+	
+	if IsValid(LookingAt) and LookingAt:GetClass() == "offset_hoverball" then
+
+		if (LookingAt:GetPos() - LocalPlayer():GetShootPos()):Length() > 300 then return end
+
+		local HBData = string.Split(LookingAt:GetNWString("OHB-BetterTip"), ",")
+		
+		surface.SetFont( "OHBTipFontSmall" )
+		local TextScaleOffset = 0
+		for I=1,#HBData do if surface.GetTextSize(HBData[I]) > TextScaleOffset then TextScaleOffset = surface.GetTextSize(HBData[I]) end end
+		BoxScaleX = BoxScaleX+TextScaleOffset
+		
+		if HBData[1] ~= "" then
+			BoxOffsetY = ScrH()/2-60
+			
+			local triangle = {{ x = BoxOffsetX-16, y = BoxOffsetY+60 }, { x = BoxOffsetX, y = BoxOffsetY+44 }, { x = BoxOffsetX, y = BoxOffsetY+76 }}
+			surface.SetDrawColor( 20, 20, 20, 255 ); draw.NoTexture(); surface.DrawPoly( triangle )
+			
+			draw.RoundedBox( 8, BoxOffsetX, BoxOffsetY-5, BoxScaleX, 142, Color( 20, 20, 20, 255 ) )
+		    draw.RoundedBox( 8, BoxOffsetX+1, BoxOffsetY-2, BoxScaleX-2, 138, Color( 60, 60, 60, 255 ) )
+			
+			local triangle = {{ x = BoxOffsetX-15, y = BoxOffsetY+60 }, { x = BoxOffsetX+1,  y = BoxOffsetY+45 },	{ x = BoxOffsetX+1,  y = BoxOffsetY+75 }}
+			surface.SetDrawColor( 60, 60, 60, 255 ); draw.NoTexture(); surface.DrawPoly( triangle )
+			
+			local Pulse = math.Clamp(math.abs( math.sin( CurTime() * 5 ) ), 0.1, 1 )
+			draw.RoundedBoxEx( 8, BoxOffsetX+1, BoxOffsetY-4, BoxScaleX-2, 30, Color( 70, 70, 70, 255 ), true, true, false, false )
+			draw.SimpleText( HBData[1], "OHBTipFontGlow", BoxOffsetX+(BoxScaleX/2), BoxOffsetY+24, Color( Pulse*255, Pulse*200, 0, 200 ), TEXT_ALIGN_CENTER, TEXT_ALIGN_CENTER)
+			draw.SimpleText( HBData[1], "OHBTipFont", BoxOffsetX+(BoxScaleX/2), BoxOffsetY+24, Color( 200,200,200 ), TEXT_ALIGN_CENTER, TEXT_ALIGN_CENTER)
+		else
+			BoxOffsetY = ScrH()/2-80
+
+			surface.SetDrawColor( 20, 20, 20, 255 ); draw.NoTexture(); surface.DrawPoly( {{ x = BoxOffsetX-16, y = BoxOffsetY+80 },	{ x = BoxOffsetX, y = BoxOffsetY+64 }, { x = BoxOffsetX, y = BoxOffsetY+96 }} )
+			
+			draw.RoundedBox( 8, BoxOffsetX, BoxOffsetY+22, BoxScaleX, 115, Color( 20, 20, 20, 255 ) )
+			draw.RoundedBox( 8, BoxOffsetX+1, BoxOffsetY+23, BoxScaleX-2, 113, Color( 60, 60, 60, 255 ) )
+
+			surface.SetDrawColor( 60, 60, 60, 255 ); draw.NoTexture(); surface.DrawPoly( {{ x = BoxOffsetX-15, y = BoxOffsetY+80 },	{ x = BoxOffsetX+1,  y = BoxOffsetY+65 }, { x = BoxOffsetX+1,  y = BoxOffsetY+95 }} )
+		end
+		
+		draw.SimpleText( "Hover height:", "OHBTipFontSmall", BoxOffsetX+10, BoxOffsetY+40, Color( 200, 200, 200 ), TEXT_ALIGN_LEFT, TEXT_ALIGN_CENTER)
+		draw.SimpleText( "Hover force:", "OHBTipFontSmall", BoxOffsetX+10, BoxOffsetY+60, Color( 200, 200, 200 ), TEXT_ALIGN_LEFT, TEXT_ALIGN_CENTER)
+		draw.SimpleText( "Air resistance:", "OHBTipFontSmall", BoxOffsetX+10, BoxOffsetY+80, Color( 200, 200, 200 ), TEXT_ALIGN_LEFT, TEXT_ALIGN_CENTER)
+		draw.SimpleText( "Angular damping:", "OHBTipFontSmall", BoxOffsetX+10, BoxOffsetY+100, Color( 200, 200, 200 ), TEXT_ALIGN_LEFT, TEXT_ALIGN_CENTER)
+		draw.SimpleText( "Brake resistance:", "OHBTipFontSmall", BoxOffsetX+10, BoxOffsetY+120, Color( 200, 200, 200 ), TEXT_ALIGN_LEFT, TEXT_ALIGN_CENTER)
+		
+		draw.SimpleText( HBData[2], "OHBTipFontSmall", BoxOffsetX+(BoxScaleX-10), BoxOffsetY+40, Color( 80, 220, 80 ), TEXT_ALIGN_RIGHT, TEXT_ALIGN_CENTER)
+		draw.SimpleText( HBData[3], "OHBTipFontSmall", BoxOffsetX+(BoxScaleX-10), BoxOffsetY+60, Color( 80, 220, 80 ), TEXT_ALIGN_RIGHT, TEXT_ALIGN_CENTER)
+		draw.SimpleText( HBData[4], "OHBTipFontSmall", BoxOffsetX+(BoxScaleX-10), BoxOffsetY+80, Color( 80, 220, 80 ), TEXT_ALIGN_RIGHT, TEXT_ALIGN_CENTER)
+		draw.SimpleText( HBData[5], "OHBTipFontSmall", BoxOffsetX+(BoxScaleX-10), BoxOffsetY+100, Color( 80, 220, 80 ), TEXT_ALIGN_RIGHT, TEXT_ALIGN_CENTER)
+		draw.SimpleText( HBData[6], "OHBTipFontSmall", BoxOffsetX+(BoxScaleX-10), BoxOffsetY+120, Color( 80, 220, 80 ), TEXT_ALIGN_RIGHT, TEXT_ALIGN_CENTER)
+	end
+end)
+
+
 function ENT:Draw()
 	-- self.BaseClass.Draw(self) -- Overrides Draw
 	self:DrawModel() -- Draws Model Client Side
+	if ShouldRenderLasers:GetBool() or ShouldAlwaysRenderLasers:GetBool() then self:DrawLaser() end
 end


### PR DESCRIPTION
**New stuff:**
- Attempted a better looking UI for the mouseover popups when looking at a hoverball.
- Added option to use parenting instead of welds to attach hoverballs. (Sturdier, but can't be updated by left-clicking)
- Added ability to ALT + left click a contraption and update all connected hoverballs at once. (Works with parented ones too)
- Added experimental "Slippery mode" that makes hoverballs slide down angled surfaces.
- Added configuration for Slippery mode under new Experimental heading. (Requires tickbox to enable)
- Added ability to visualise the traces with lasers. Can be configured to only show when holding the tool.
- Added config option to show the lasers even when not holding the tool, cause I thought they looked cool.

**Changes:**
- Made a config option for setting hover height with SHIFT + left click. (Off by default so new users don't do it by accident)
- Moved settings update on left-click code to own function so it can be used for ALT + click as well.
- Moved tool settings to their own section. (Tool settings are client-only and not written to the hoverball)
- Added small cube (_models/hunter/plates/plate.mdl_) to available models list.
- Changed some menu labels.

**Fixes:**
- Fixed water detection being broken. (Wrong variable name, my bad.)
- Limited hoverball hover height variable from going below 0, as that would be pointless.
- Fixed tapping the brake key while HB is disabled clearing the tooltip status display.
