### PR TITLE
Unified controls + Updated tool UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This version features several fixes and improvements over Marum's original versi
 - Experimental 'Slippery mode' allows your vehicles to slide down slopes. Make a hover-sled!
 - Sleek-ish UI that shows info when looking at a hoverball.
 - Can now click existing hoverballs to update their values without having to remove and replace them.
-- Update settings on a whole contraption in one go with ALT + Left click.
+- Update settings on a whole contraption in one go with SHIFT + right click.
 - Configuration options for everything you could want, and probably even some stuff you didn't.
 - Lasers! Everybody loves lasers.
 - More that can be found on the Steam workshop page: https://steamcommunity.com/sharedfiles/filedetails/?id=2502939629

--- a/lua/entities/offset_hoverball/cl_init.lua
+++ b/lua/entities/offset_hoverball/cl_init.lua
@@ -42,7 +42,7 @@ function ENT:DrawLaser()
 	
 	if ShouldAlwaysRenderLasers:GetBool() or (LocalPlayer():GetActiveWeapon():GetClass() == "gmod_tool" and ToolMode:GetString() == "offset_hoverball") then
 
-		local hbpos = self:GetPos()
+		local hbpos = self:WorldSpaceCenter()
 		local function traceFilter(ent) if (ent:GetClass() == "prop_physics") then return false end end
 		local tr = util.TraceLine({
 			start  = hbpos,


### PR DESCRIPTION
Fixes:
- Changed incorrect tool control labels in offset_hoverball.lua
- Fixed 'self' error on line 117.

Changes:
- Unified controls to use SHIFT + LMB/RMB/Reload instead of ALT or E.
- Changed clientside laser rendering to use center of HB hitbox.
- Made the toolmenu look a bit nicer + updated labels.
- Changed ApplyContraption() notification wording.
- Actions that modify contraptions don't run if a hoverball is selected directly.

Added:
- Tool information HUD now shows more controls when holding SHIFT.