### PR TITLE
Fixed: Use different variables for NW tip and split

### DIFF
--- a/lua/entities/offset_hoverball/cl_init.lua
+++ b/lua/entities/offset_hoverball/cl_init.lua
@@ -7,7 +7,11 @@ local ShouldRenderLasers = GetConVar("offset_hoverball_showlasers")
 local ShouldAlwaysRenderLasers = GetConVar("offset_hoverball_alwaysshowlasers")
 local ToolMode = GetConVar("gmod_toolmode")
 
--- Baed on garrysmod/lua/derma/init.lua it looks like the game comes with the Roboto font, so it should be safe to use on all platforms?
+--[[
+ Based on garrysmod/lua/derma/init.lua
+ It looks like the game comes with the Roboto font,
+ so it should be safe to use on all platforms?
+]]
 surface.CreateFont("OHBTipFont", {
 	font = "Roboto Regular",
 	size = 24,
@@ -48,7 +52,12 @@ local CoOHBBack60 = Color(60, 60, 60)
 local CoOHBBack70 = Color(70, 70, 70)
 local CoLaserBeam = Color(100, 100, 255)
 
-local TableDrPoly = {{x = 0, y = 0}, {x = 0, y = 0}, {x = 0, y = 0}}
+local TableDrPoly = {
+	{x = 0, y = 0},
+	{x = 0, y = 0},
+	{x = 0, y = 0}
+}; TableDrPoly.Size = #TableDrPoly
+
 local TableOHBInf = {
 	{2, "Hover height:    "},
 	{3, "Hover force:     "},
@@ -69,10 +78,11 @@ end
 function ENT:DrawLaser()
 	if not IsValid(self) then return end
 	local OwnPlayer = LocalPlayer()
-	if ShouldAlwaysRenderLasers:GetBool() or (OwnPlayer:GetActiveWeapon():GetClass() == "gmod_tool" and ToolMode:GetString() == "offset_hoverball") then
-
+	if ShouldAlwaysRenderLasers:GetBool() or
+		(ToolMode:GetString() == "offset_hoverball" and
+		 OwnPlayer:GetActiveWeapon():GetClass() == "gmod_tool")
+	then -- Draw the hoverball lasers
 		local hbpos = self:WorldSpaceCenter()
-		local function traceFilter(ent) if (ent:GetClass() == "prop_physics") then return false end end
 		local tr = self:GetTrace(hbpos, -500)
 
 		if tr.Hit then
@@ -95,20 +105,20 @@ hook.Add("HUDPaint", "OffsetHoverballs_MouseoverUI", function()
 	if LookingAt:GetClass() ~= "offset_hoverball" then return end
 	if (LookingAt:GetPos():DistToSqr(OwnPlayer:GetShootPos()) > 30000) then return end
 
-
-	local HBData = LookingAt:GetNWString("OHB-BetterTip")
-	if HBData == nil or HBData == "" then return end
-	HBData = string.Split(HBData, ",")
+	local TipNW = LookingAt:GetNWString("OHB-BetterTip")
+	if not TipNW or TipNW == "" then return end
+	local HBData, TextSO = TipNW:Split(","), 0
 
 	surface.SetFont("OHBTipFontSmall")
-	local TextScaleOffset = 0
+
 	for oi = 1, #HBData do
-		if surface.GetTextSize(HBData[oi]) > TextScaleOffset then
-			TextScaleOffset = surface.GetTextSize(HBData[oi])
+		local dat = HBData[oi]
+		if surface.GetTextSize(dat) > TextSO then
+			TextSO = surface.GetTextSize(dat)
 		end
 	end
 
-	BoxScaleX = BoxScaleX + TextScaleOffset
+	BoxScaleX = BoxScaleX + TextSO
 
 	-- Overlay first argument is present
 	if HBData[1] ~= "" then
@@ -136,6 +146,7 @@ hook.Add("HUDPaint", "OffsetHoverballs_MouseoverUI", function()
 
 		DrawTablePolygon(CoOHBBack60, BoxOffsetX - 15, BoxOffsetY + 80, BoxOffsetX + 1, BoxOffsetY + 65, BoxOffsetX + 1, BoxOffsetY + 95)
 	end
+
 	for di = 1, TableOHBInf.Size do
 		local inf = TableOHBInf[di]
 		local hbx = BoxOffsetX + 10

--- a/lua/entities/offset_hoverball/cl_init.lua
+++ b/lua/entities/offset_hoverball/cl_init.lua
@@ -45,8 +45,6 @@ surface.CreateFont("OHBTipFontSmall", {
 local BoxOffsetX = (ScrW() / 2) + 60
 local BoxOffsetY = (ScrH() / 2) - 50
 
-local VecUp = Vector(0, 0, 1)
-
 local CoOHBName = Color(200, 200, 200)
 local CoOHBValue = Color(80, 220, 80)
 local CoOHBBack20 = Color(20, 20, 20)
@@ -102,7 +100,7 @@ function ENT:DrawLaser()
 			cam.Start3D()
 				render.SetMaterial(laser)
 				render.DrawBeam(hbpos, tr.HitPos, 5, 0, 0, CoLaserBeam)
-				render.SetMaterial(light); tr.HitPos:Add(VecUp)
+				render.SetMaterial(light); tr.HitPos.z = tr.HitPos.z + 1
 				render.DrawQuadEasy(tr.HitPos, tr.HitNormal, 30, 30, CoLaserBeam)
 				render.DrawQuadEasy(hbpos, OwnPlayer:GetAimVector(), 30, 30, CoLaserBeam)
 			cam.End3D()

--- a/lua/entities/offset_hoverball/cl_init.lua
+++ b/lua/entities/offset_hoverball/cl_init.lua
@@ -45,12 +45,15 @@ surface.CreateFont("OHBTipFontSmall", {
 local BoxOffsetX = (ScrW() / 2) + 60
 local BoxOffsetY = (ScrH() / 2) - 50
 
+local VecUp = Vector(0, 0, 1)
+
 local CoOHBName = Color(200, 200, 200)
 local CoOHBValue = Color(80, 220, 80)
 local CoOHBBack20 = Color(20, 20, 20)
 local CoOHBBack60 = Color(60, 60, 60)
 local CoOHBBack70 = Color(70, 70, 70)
 local CoLaserBeam = Color(100, 100, 255)
+local CoPulseMode = Color(0, 0, 0, 200)
 
 local TableDrPoly = {
 	{x = 0, y = 0},
@@ -75,6 +78,16 @@ local function DrawTablePolygon(co, x1, y1, x2, y2, x3, y3)
 	surface.DrawPoly(TableDrPoly)
 end
 
+local function GetPulseColor()
+	local Tim = 3 * CurTime()
+	local Frc = Tim - math.floor(Tim)
+	local Mco = math.abs(2 * (Frc - 0.5))
+	local Com = math.Clamp(Mco, 0.1, 1)
+	CoPulseMode.r = Com * 255
+	CoPulseMode.g = Com * 200
+	return CoPulseMode
+end
+
 function ENT:DrawLaser()
 	if not IsValid(self) then return end
 	local OwnPlayer = LocalPlayer()
@@ -89,8 +102,8 @@ function ENT:DrawLaser()
 			cam.Start3D()
 				render.SetMaterial(laser)
 				render.DrawBeam(hbpos, tr.HitPos, 5, 0, 0, CoLaserBeam)
-				render.SetMaterial(light)
-				render.DrawQuadEasy(tr.HitPos + Vector(0, 0, 1), tr.HitNormal, 30, 30, CoLaserBeam)
+				render.SetMaterial(light); tr.HitPos:Add(VecUp)
+				render.DrawQuadEasy(tr.HitPos, tr.HitNormal, 30, 30, CoLaserBeam)
 				render.DrawQuadEasy(hbpos, OwnPlayer:GetAimVector(), 30, 30, CoLaserBeam)
 			cam.End3D()
 		end
@@ -122,7 +135,7 @@ hook.Add("HUDPaint", "OffsetHoverballs_MouseoverUI", function()
 
 	-- Overlay first argument is present
 	if HBData[1] ~= "" then
-		BoxOffsetY = ScrH() / 2 - 60
+		BoxOffsetY, CoDyn = ScrH() / 2 - 60, GetPulseColor()
 
 		DrawTablePolygon(CoOHBBack20, BoxOffsetX - 16, BoxOffsetY + 60, BoxOffsetX, BoxOffsetY + 44, BoxOffsetX, BoxOffsetY + 76)
 
@@ -131,8 +144,6 @@ hook.Add("HUDPaint", "OffsetHoverballs_MouseoverUI", function()
 
 		DrawTablePolygon(CoOHBBack60, BoxOffsetX - 15, BoxOffsetY + 60, BoxOffsetX + 1, BoxOffsetY + 45, BoxOffsetX + 1, BoxOffsetY + 75)
 
-		local Pulse = math.Clamp(math.abs(math.sin(CurTime() * 5)), 0.1, 1)
-		local CoDyn = Color(Pulse * 255, Pulse * 200, 0, 200)
 		draw.RoundedBoxEx(8, BoxOffsetX + 1, BoxOffsetY - 4, BoxScaleX - 2, 30, CoOHBBack70, true, true, false, false)
 		draw.SimpleText(HBData[1], "OHBTipFontGlow", BoxOffsetX + (BoxScaleX / 2), BoxOffsetY + 24, CoDyn, TEXT_ALIGN_CENTER, TEXT_ALIGN_CENTER)
 		draw.SimpleText(HBData[1], "OHBTipFont", BoxOffsetX + (BoxScaleX / 2), BoxOffsetY + 24, CoOHBName, TEXT_ALIGN_CENTER, TEXT_ALIGN_CENTER)

--- a/lua/entities/offset_hoverball/init.lua
+++ b/lua/entities/offset_hoverball/init.lua
@@ -4,9 +4,9 @@ AddCSLuaFile("shared.lua")
 include("shared.lua")
 
 local statInfo = {"Brake enabled", "Hover disabled"}
--- local formInfo = "Hover height: %g\nForce: %g\nAir resistance: %g\nAngular damping: %g\n Brake resistance: %g"
 local formInfoBT = "%g,%g,%g,%g,%g" -- For better tooltip.
-local brakColr = {Color(255, 100, 100), Color(255, 255, 255)}
+local CoBrake1 = Color(255, 100, 100)
+local CoBrake2 = Color(255, 255, 255)
 
 function ENT:UpdateMask()
 	self.mask = MASK_NPCWORLDSTATIC
@@ -27,8 +27,8 @@ function ENT:UpdateCollide()
 end
 
 function ENT:UpdateHoverText(str)
-	--self:SetOverlayText(tostring(str or "")..formInfo:format(self.hoverdistance, self.hoverforce, self.damping, self.rotdamping, self.brakeresistance))
-	self:SetNWString("OHB-BetterTip", tostring(str or "")..","..formInfoBT:format(self.hoverdistance, self.hoverforce, self.damping, self.rotdamping, self.brakeresistance))
+	self:SetNWString("OHB-BetterTip", tostring(str or "")..","..
+		formInfoBT:format(self.hoverdistance, self.hoverforce, self.damping, self.rotdamping, self.brakeresistance))
 end
 
 function ENT:Initialize()
@@ -93,10 +93,9 @@ function ENT:PhysicsUpdate()
 	if (tr.distance < hoverdistance) then
 		force = -(tr.distance - hoverdistance) * hoverforce
 		phys:ApplyForceCenter(Vector(0, 0, -phys:GetVelocity().z * 8))
-		
-		
+
 		-- Experimental sliding physics:
-		if tr.Hit then		
+		if tr.Hit then
 			if math.abs(tr.HitNormal.x) > self.minslipangle or math.abs(tr.HitNormal.y) > self.minslipangle then
 				phys:ApplyForceCenter(Vector(tr.HitNormal.x*self.slip, tr.HitNormal.y*self.slip, 0))
 			end
@@ -142,13 +141,13 @@ if (SERVER) then
 		
 		if (not ent.hoverenabled) then
 			ent.damping_actual = ent.damping
-			ent:SetColor(brakColr[2])
+			ent:SetColor(CoBrake2)
 
 			ent:UpdateHoverText(statInfo[2] .. "\n") -- Shows disabled header on tooltip.
 		else
 			ent:UpdateHoverText()
 			ent:PhysWake() -- Nudges the physics entity out of sleep, was sometimes causing issues.
-		end		
+		end
 		
 		ent:PhysicsUpdate()
 		return true
@@ -161,11 +160,11 @@ if (SERVER) then
 		if (keydown and ent.hoverenabled) then -- Brakes won't work if hovering is disabled.
 			ent.damping_actual = ent.brakeresistance
 			ent:UpdateHoverText(statInfo[1] .. "\n")
-			ent:SetColor(brakColr[1])
+			ent:SetColor(CoBrake1)
 		else
 			ent.damping_actual = ent.damping
 			ent:UpdateHoverText()
-			ent:SetColor(brakColr[2])
+			ent:SetColor(CoBrake2)
 		end
 		
 		ent:PhysicsUpdate()
@@ -186,11 +185,11 @@ if WireLib then
 			if value >= 1 then
 				self.damping_actual = self.brakeresistance
 				title = statInfo[1] .. "\n"
-				self:SetColor(brakColr[1])
+				self:SetColor(CoBrake1)
 				self:PhysicsUpdate()
 			else
 				self.damping_actual = self.damping
-				self:SetColor(brakColr[2])
+				self:SetColor(CoBrake2)
 				self:PhysicsUpdate()
 			end
 

--- a/lua/entities/offset_hoverball/shared.lua
+++ b/lua/entities/offset_hoverball/shared.lua
@@ -14,13 +14,13 @@ ENT.AdminOnly = false -- This can't be true or they won't be spawnable.
 local function traceFilter(ent) if (ent:GetClass() == "prop_physics") then return false end end
 
 function ENT:GetTrace(origin, length, output)
-  local hover, hmask = self.hoverdistance, self.mask
-  local hleng = (length or (-hover * 2))
-  local hbpos = (origin or self:GetPos())
-  local tr = util.TraceLine({
-    start  = hbpos, output = output,
-    endpos = hbpos + Vector(0, 0, hleng),
-    filter = traceFilter, mask = hmask
-  }); tr.distance = math.abs(hleng) * tr.Fraction
-  return tr
+	local hover, hmask = self.hoverdistance, self.mask
+	local hleng = (length or (-hover * 2))
+	local hbpos = (origin or self:GetPos())
+	local tr = util.TraceLine({
+		start  = hbpos, output = output,
+		endpos = hbpos + Vector(0, 0, hleng),
+		filter = traceFilter, mask = hmask
+	}); tr.distance = math.abs(hleng) * tr.Fraction
+	return tr
 end


### PR DESCRIPTION
Changed: Moved some long lines to multi-line
Changed: Hover-ball shared file to have TAB indentations
Optimized: Use string meta-method for splitting
Optimized: Index `HBData` single time by reference
Removed: `traceFilter` is not used on the client
Updated: Ensure one empty line at the end of the file