### PR TITLE
Various tweaks & fixes

### DIFF
--- a/lua/entities/offset_hoverball/init.lua
+++ b/lua/entities/offset_hoverball/init.lua
@@ -115,10 +115,18 @@ function ENT:UpdateFilter(set)
 	end
 end
 
+
+-- Changed this so we just send "1", "2" or "" as the header and translate on the client.
+-- Enables support for multiple languages and reduces NWString size.
+
+-- ball:UpdateHoverText()		-- No header
+-- ball:UpdateHoverText("1")	-- Brakes on
+-- ball:UpdateHoverText("2")	-- Hover disabled
+
 function ENT:UpdateHoverText(str)
-	self:SetNWString("OHB-BetterTip", tostring(str or "")..","..
-		formInfoBT:format(self.hoverdistance, self.hoverforce, self.damping,
-		                  self.rotdamping   , self.hovdamping, self.brakeresistance))
+
+	-- Putting this on more than 1 line broke the NWstring. I am scared to touch it again.
+	self:SetNWString("OHB-BetterTip", (str or "")..","..formInfoBT:format(self.hoverdistance, self.hoverforce, self.damping, self.rotdamping, self.hovdamping, self.brakeresistance))
 end
 
 function ENT:Initialize()
@@ -180,7 +188,7 @@ function ENT:PhysicsUpdate()
 		-- Bit scuffed, but doesn't use an extra var
 		-- Quick-fix for adjusting height with brakes on removing the header.
 		if self.damping_actual == self.brakeresistance then
-			self:UpdateHoverText(self:GetHeader(1))
+			self:UpdateHoverText("1")
 		else
 			self:UpdateHoverText()
 		end
@@ -239,7 +247,7 @@ numpad.Register(gsClass.."_toggle", function(pl, ent, keydown)
 	if (not ent.hoverenabled) then
 		ent.damping_actual = ent.damping
 		ent:SetColor(CoBrake2)
-		ent:UpdateHoverText(ent:GetHeader(2)) -- Shows disabled header on tooltip.
+		ent:UpdateHoverText("2") -- Shows disabled header on tooltip.
 	else
 		ent:UpdateHoverText()
 		ent:PhysWake() -- Nudges the physics entity out of sleep, was sometimes causing issues.
@@ -255,7 +263,7 @@ numpad.Register(gsClass.."_brake", function(pl, ent, keydown)
 
 	if (keydown and ent.hoverenabled) then
 		ent.damping_actual = ent.brakeresistance
-		ent:UpdateHoverText(ent:GetHeader(1))
+		ent:UpdateHoverText("1")
 		ent:SetColor(CoBrake1)
 	else
 		ent.damping_actual = ent.damping
@@ -278,7 +286,7 @@ if WireLib then
 
 			if (value >= 1 and self.hoverenabled) then
 				self.damping_actual = self.brakeresistance
-				self:UpdateHoverText(self:GetHeader(1))
+				self:UpdateHoverText("1")
 				self:SetColor(CoBrake1)
 			else
 				self.damping_actual = self.damping
@@ -297,7 +305,7 @@ if WireLib then
 			else
 				self.damping_actual = self.damping
 				self:SetColor(CoBrake2)
-				self:UpdateHoverText(self:GetHeader(2))
+				self:UpdateHoverText("2")
 			end
 			self:PhysicsUpdate()
 			return
@@ -374,7 +382,7 @@ function ENT:Setup(ply, pos, ang, hoverdistance, hoverforce, damping,
 	-- No OnUp func required for toggle.
 	self.imp_toggle = numpad.OnDown(ply, self.key_toggle, gsModes.."_toggle", self, true)
 
-	-- Update settings to our new values. Place value clampings here in this method
+	-- Update settings to our new values. Place value clampings here in this method.
 	self.hoverforce      = math.Clamp(tonumber(hoverforce)    or 0, 0, 999999) -- Clamped to fix physics crash.
 	self.hoverdistance   = math.Clamp(tonumber(hoverdistance) or 0, 0, 999999)
 	self.adjustspeed     = tonumber(adjustspeed    )
@@ -393,20 +401,18 @@ function ENT:Setup(ply, pos, ang, hoverdistance, hoverforce, damping,
 	self:UpdateMask()
 	self:UpdateFilter()
 	self:UpdateCollide()
-	self:UpdateHoverText(self:GetHeader(2))
+	self:UpdateHoverText((self.start_on and "" or "2"))
 
 	-- Fixes issue with air-resi not updating correctly.
 	self.damping_actual = self.damping
 
-	-- Start the hoverball if applicavle
+	-- Start the hoverball if applicable.
 	self.hoverenabled = self.start_on
 
 	self:PhysicsUpdate()
 end
 
---[[
-	Specific stuff to do after HB is pasted
-]]
+-- Specific stuff to do after HB is pasted
 function ENT:PostEntityPaste(ply, ball, info)
 	ball:UpdateMask()
 	if(ball.detects_props) then
@@ -415,5 +421,5 @@ function ENT:PostEntityPaste(ply, ball, info)
 		ball:UpdateFilter(false)
 	end
 	ball:UpdateCollide()
-	ball:UpdateHoverText(ball:GetHeader(2))
+	ball:UpdateHoverText((self.start_on and "" or "2"))
 end

--- a/lua/entities/offset_hoverball/shared.lua
+++ b/lua/entities/offset_hoverball/shared.lua
@@ -2,27 +2,8 @@ ENT.Type = "anim"
 ENT.Base = "base_gmodentity"
 ENT.Category = "Other"
 ENT.PrintName = "Offset Hoverball"
-ENT.Author = "" --Autor name... Sony-dev  ?
-ENT.Contact = "" -- Autor e-mail
-ENT.Purpose = "Spawn using the tool, not this menu please."
-ENT.Instructions = "Snap to a prop to make it hover at a distance"
-ENT.Spawnable = false -- Disable spawning via entities menu. Use the tool
+ENT.Spawnable = false -- Disable spawning via entities menu. Use the tool.
 ENT.AdminOnly = false -- This can't be true or they won't be spawnable.
-
-local gsModes = "offset_hoverball"
-local gsClass = "offset_hoverball"
-
-local statInfo = {"Brake enabled", "Hover disabled"}
-
-function ENT:GetHeader(idx)
-	return (self.hoverenabled and "" or tostring(idx and statInfo[idx] or "N/A").."\n")
-end
-
-function ENT:SetPosition(trace, mar)
-	local pos, mar = self:GetPos(), (tonumber(mar) or 0)
-	local pnt = self:NearestPoint(pos - (trace.HitNormal * mar))
-	pos:Sub(pnt); pos:Add(trace.HitPos); self:SetPos(pos)
-end
 
 local function traceFilter(ent) if (ent:GetClass() == "prop_physics") then return false end end
 

--- a/lua/weapons/gmod_tool/stools/offset_hoverball.lua
+++ b/lua/weapons/gmod_tool/stools/offset_hoverball.lua
@@ -205,11 +205,13 @@ end
 
 function TOOL:ApplyContraption(trace, func, atyp)
 	if (CLIENT) then return false end
-	-- Read the trace entiy and validate it
-	local tent = trace.Entity; if not IsValid(tent) then
-		self:NotifyAction("Contraption is not eligible for this action!", "ERROR") end
-	local tenc = tent:GetClass(); if tenc == "" then
-		self:NotifyAction("Trace class is not eligible for this action!", "ERROR") end
+	
+	-- Read the trace entity and validate it.
+	local tent = trace.Entity
+	if not IsValid(tent) then self:NotifyAction("Contraption is not eligible for this action!", "ERROR") return end
+	local tenc = tent:GetClass()
+	if tenc == "" then self:NotifyAction("Trace class is not eligible for this action!", "ERROR") return end
+	
 	-- For this one we can click on a prop that has multiple hoverballs attached and update them all at once.
 	local prc, HB = tostring(atyp or "N/A"), 0
 	local CN = constraint.GetAllConstrainedEntities( tent )
@@ -315,8 +317,7 @@ function TOOL:LeftClick(trace)
 
 		if not IsValid(ball) then return false end
 
-		-- Adjust the position serverside
-		ball:SetPosition(trace, 512)
+		ball:SetPos(trace.HitPos)
 
 		local weld = constraint.Weld(ball, tent, 0, trace.PhysicsBone, 0, true, true)
 
@@ -326,8 +327,8 @@ function TOOL:LeftClick(trace)
 		-- Hold shift when placing to automatically set hover height.
 		if (ply:KeyDown(IN_SPEED))  then
 			local tr = ball:GetTrace(nil, -50000)
-			ball.hoverdistance = tr.distance
-			ball:UpdateHoverText(ball:GetHeaderDisable())
+			ball.hoverdistance = tr.distance			
+			if start_on then ball:UpdateHoverText() else ball:UpdateHoverText("2") end
 		end
 
 		if useparenting then ball:SetParent(tent) end
@@ -446,21 +447,17 @@ function TOOL.BuildCPanel(panel)
 	pItem:DockMargin(8,10,0,0)
 
 	pItem = panel:CheckBox(language.GetPhrase("tool."..gsModes..".detects_water"), gsModes.."_detects_water")
-	pItem:SetTooltip(language.GetPhrase("tool."..gsModes..".detects_water_tt"))
 	pItem:SetChecked(ConVarsDefault[gsModes.."_detects_water"])
 	pItem:DockMargin(0,10,0,0)
 
 	pItem = panel:CheckBox(language.GetPhrase("tool."..gsModes..".detects_props"), gsModes.."_detects_props")
 	pItem:SetTooltip(language.GetPhrase("tool."..gsModes..".detects_props_tt"))
 	pItem:SetChecked(ConVarsDefault[gsModes.."_detects_props"])
-	pItem:DockMargin(0,10,0,0)
 
 	pItem = panel:CheckBox(language.GetPhrase("tool."..gsModes..".nocollide"), gsModes.."_nocollide")
-	pItem:SetTooltip(language.GetPhrase("tool."..gsModes..".nocollide_tt"))
 	pItem:SetChecked(ConVarsDefault[gsModes.."_nocollide"])
 
 	pItem = panel:CheckBox(language.GetPhrase("tool."..gsModes..".start_on"), gsModes.."_start_on")
-	pItem:SetTooltip(language.GetPhrase("tool."..gsModes..".start_on_tt"))
 	pItem:SetChecked(ConVarsDefault[gsModes.."_start_on"])
 
 	pItem = vgui.Create("CtrlNumPad", panel)
@@ -487,9 +484,9 @@ function TOOL.BuildCPanel(panel)
 	pItem:SetDefaultValue(ConVarsDefault[gsModes.."_brake_resistance"])
 	pItem.Label:SetTooltip(language.GetPhrase("tool."..gsModes..".brake_resistance_tt"))
 
-	pItem = panel:ControlHelp(language.GetPhrase("tool."..gsModes..".help1"))
+	pItem = panel:ControlHelp(language.GetPhrase("tool."..gsModes..".slider_help1"))
 	pItem:DockMargin(10,0,0,0)
-	pItem = panel:ControlHelp(language.GetPhrase("tool."..gsModes..".help2"))
+	pItem = panel:ControlHelp(language.GetPhrase("tool."..gsModes..".slider_help2"))
 	pItem:DockMargin(10,0,0,0)
 
 	Subheading = panel:Help(language.GetPhrase("tool."..gsModes..".set_def"))
@@ -513,11 +510,10 @@ function TOOL.BuildCPanel(panel)
 	pItem:SetChecked(ConVarsDefault[gsModes.."_showdecimals"])
 
 	pItem = panel:CheckBox(language.GetPhrase("tool."..gsModes..".useparenting"), gsModes.."_useparenting")
-	pItem:SetTooltip(language.GetPhrase("tool."..gsModes..".useparenting_tt"))
 	pItem:SetChecked(ConVarsDefault[gsModes.."_useparenting"])
 
-	panel:ControlHelp(language.GetPhrase("tool."..gsModes..".help1"))
-	panel:ControlHelp(language.GetPhrase("tool."..gsModes..".help2"))
+	panel:ControlHelp(language.GetPhrase("tool."..gsModes..".parent_help1"))
+	panel:ControlHelp(language.GetPhrase("tool."..gsModes..".parent_help2"))
 
 	Subheading = panel:Help(language.GetPhrase("tool."..gsModes..".set_exp"))
 	Subheading:SetFont("DefaultBold")
@@ -527,7 +523,6 @@ function TOOL.BuildCPanel(panel)
 	pItem:DockMargin(1,0,5,0)
 
 	SlipToggle = panel:CheckBox(language.GetPhrase("tool."..gsModes..".slipenabled"), gsModes.."_slipenabled")
-	SlipToggle:SetTooltip(language.GetPhrase("tool."..gsModes..".slipenabled_tt"))
 	SlipToggle:SetChecked(ConVarsDefault[gsModes.."_slipenabled"])
 
 	SlipNSlider = panel:NumSlider(language.GetPhrase("tool."..gsModes..".slip"), gsModes.."_slip", 0, 5000)

--- a/resource/localization/en/offset_hoverball.properties
+++ b/resource/localization/en/offset_hoverball.properties
@@ -1,4 +1,5 @@
 ﻿
+# Appears in toolgun menu:
 tool.offset_hoverball.name=Hoverball - Offset
 tool.offset_hoverball.desc=Hoverballs that keep relative distance to the ground and can go up and down slopes
 tool.offset_hoverball.holdshift=Hold SHIFT for more options
@@ -21,13 +22,10 @@ tool.offset_hoverball.hover_damping=Hover Damping
 tool.offset_hoverball.hover_damping_tt=Controls how springy the hover effect is.\nLower values are more bouncy.
 tool.offset_hoverball.mouseui=• Mouse over slider labels to see more info.
 tool.offset_hoverball.detects_water=Hovers over water
-tool.offset_hoverball.detects_water_tt=When enabled traces can hit the water and entity can hover over it
-tool.offset_hoverball.detects_props=Hovers over props
-tool.offset_hoverball.detects_props_tt=When enabled traces can hit props and entity can hover over them
+tool.offset_hoverball.detects_props=Hovers over entities/props
+tool.offset_hoverball.detects_props_tt=Enable to climb over basically anything, disable to follow terrain only.
 tool.offset_hoverball.nocollide=Disable collisions
-tool.offset_hoverball.nocollide_tt=Disables hoverball collisions
 tool.offset_hoverball.start_on=Start on
-tool.offset_hoverball.start_on_tt=Disables hoverball collisions
 tool.offset_hoverball.key_heightup=Increase height
 tool.offset_hoverball.key_heightdown=Decrease height
 tool.offset_hoverball.key_toggle=Toggle on/off
@@ -36,31 +34,43 @@ tool.offset_hoverball.adjust_speed=Height adjust rate
 tool.offset_hoverball.adjust_speed_tt=Controls how fast the hoverball moves up/down\nwhen the height adjust keys are pressed.\nHigher values move faster.
 tool.offset_hoverball.brake_resistance=Braking resistance
 tool.offset_hoverball.brake_resistance_tt=Controls how much extra air drag is added when\nthe brake key is held.\nHigher values will stop faster.
-tool.offset_hoverball.help1=• Keyboard controls are optional.
-tool.offset_hoverball.help2=• Brake key increases air resistance while held.
+tool.offset_hoverball.slider_help1=• Keyboard controls are optional.
+tool.offset_hoverball.slider_help2=• Brake key increases air resistance while held.
 tool.offset_hoverball.set_def=Tool settings:
 tool.offset_hoverball.set_exp=Experimental settings:
 tool.offset_hoverball.copykeybinds=Right-click settings copy includes keybinds
-tool.offset_hoverball.copykeybinds_tt=Right click will also copy keybinds
+tool.offset_hoverball.copykeybinds_tt=Disable to preserve your hotkeys when copying settings with right-click.
 tool.offset_hoverball.showlasers=Visualise traces when holding toolgun
-tool.offset_hoverball.showlasers_tt=Enable for making sure to always render traces when holding toolgun
+tool.offset_hoverball.showlasers_tt=Represent the traces used to detect objects as lasers.
 tool.offset_hoverball.alwaysshowlasers=Always show traces
-tool.offset_hoverball.alwaysshowlasers_tt=Enable for making sure to always render traces
+tool.offset_hoverball.alwaysshowlasers_tt=Enable to show hoverball traces even when not holding the toolgun.
 tool.offset_hoverball.showdecimals=Show decimals on hover UI
-tool.offset_hoverball.showdecimals_tt=Enable to also draw the fractional part of the ball parameters
+tool.offset_hoverball.showdecimals_tt=Shows decimal values on UI when looking at a hoverball.\nFor precision enjoyers.
 tool.offset_hoverball.useparenting=Attach hoverballs using parent instead of weld
-tool.offset_hoverball.useparenting_tt=When enabled script uses parenting instead of a weld
 tool.offset_hoverball.set_slip=Slippery mode will cause hoverballs to slide on uneven surfaces.\nBalance settings with air resistance for best results.
 tool.offset_hoverball.slipenabled=Enable slippery mode
-tool.offset_hoverball.slipenabled_tt=Enables hoverball slip on an inclined plane
 tool.offset_hoverball.slip=Slipperiness
-tool.offset_hoverball.slip_tt=Amount the hoverball will slip back by. Higher values make it slip more.
+tool.offset_hoverball.slip_tt=Controls how much the hoverball slides on angled surfaces.\nHigher values slide more.
 tool.offset_hoverball.minslipangle=Minimum slip angle
-tool.offset_hoverball.minslipangle_tt=How steep an incline has to be before we start slipping
-tool.offset_hoverball.help1=• More sturdy, but can't be updated with right-click.
-tool.offset_hoverball.help2=• SHIFT-RMB still works to update them, however.
+tool.offset_hoverball.minslipangle_tt=How steep an incline must be before we start to slide.
+tool.offset_hoverball.parent_help1=• More sturdy, but can't be updated with right-click.
+tool.offset_hoverball.parent_help2=• SHIFT-RMB still works to update them, however.
 tool.offset_hoverball.wire_on=✔ Wiremod integration enabled
 tool.offset_hoverball.wire_off=✖ Wiremod integration disabled ( Wiremod is not installed )
+
+# Appears on menu when looking at a hoverball:
+hoverui.header.brake_enabled=Brake enabled
+hoverui.header.hover_disabled=Hover disabled
+
+# Don't forget the ":" for these ones:
+hoverui.header.hover_height=Hover height:
+hoverui.header.hover_force=Hover force:
+hoverui.header.air_resistance=Air resistance:
+hoverui.header.angular_damping=Angular damping:
+hoverui.header.hover_damping=Hover damping:
+hoverui.header.brake_resistance=Brake resistance:
+
+# Misc:
 undone.offset_hoverball=Undone offset hoverball
 sbox_maxoffset_hoverball=Change this to adjust the maximum offset hoverballs
 Cleanup_offset_hoverball=Offset hoverballs


### PR DESCRIPTION
- Added returns to failed validation checks for TOOL:ApplyContraption in stools/offset_hoverball.lua
- Removed author, contact, etc entries from shared.lua as they don't actually appear ingame anywhere anyway.
- Removed GetHeader and SetPosition functions from shared.lua because we don't need them anymore.
- Changed UpdateHoverText so the server sends short codes and the client translates them. (Supports multiple languages, smaller netmessages, cleaner code)
- Added translations to resource file for hover menu.
- Fixed misaligned header in hover UI.
- Made hover UI box scale based on text size. (Font size is the same across all resolutions, scaling based on ScrW causes text overlap)
- Fixed UI always showing HBs spawning with hover disabled regardless of actual setting.
- Showdecimals now uses cvar change callback to update, instead of checking every frame in HUDPaint.
- Fixed misaligned checkbox.
- Fixed help translations having duplicate tags.
- Removed tooltips from some of the more obvious stuff ("Hovers over water"), or things that already have help text. (Slippery mode)
- Fixed brakes header not appearing.