### PR TITLE
More wire fixes

### DIFF
--- a/lua/entities/offset_hoverball/cl_init.lua
+++ b/lua/entities/offset_hoverball/cl_init.lua
@@ -19,7 +19,7 @@ local laser = Material("sprites/bluelaser1")
 local light = Material("Sprites/light_glow02_add")
 
 surface.CreateFont("OHBTipFont", {
-	font = "Roboto Regular", 
+	font = "Roboto Regular",
 	size = 24,
 	weight = 13,
 	blursize = 0,
@@ -238,10 +238,10 @@ function ENT:DrawInfoContent(TData, PosX, PosY, SizX, PadX, PadY)
 	for di = 1, TableOHBInf.Size do
 		local inf = TableOHBInf[di]
 		local idx, txt = inf.ID, inf.Name
-		
+
 		local hby = PosY + ((di - 1) * TxtY)
 		local hbx, hvx = (PosX + PadX), (PosX + (SizX - PadX))
-		
+
 		draw.SimpleText(txt, Font, hbx, hby, CoOHBName, TEXT_ALIGN_LEFT, TEXT_ALIGN_CENTER)
 		draw.SimpleText(TData[idx], Font, hvx, hby, CoOHBValue, TEXT_ALIGN_RIGHT, TEXT_ALIGN_CENTER)
 	end
@@ -307,7 +307,7 @@ hook.Add("HUDPaint", "OffsetHoverballs_MouseoverUI", function()
 	local SizeP = 25
 	-- X draw coordinate for the pointy triangle.
 	local PoinX = HBPos:ToScreen().y - SizeP * 0.5
-	
+
 	-- This code should support resizing the box to any value, as well as any language for the left labels.
 	-- The box should grow dynamically in order to be able to contain all the labels and values.
 	-- Width of the box longest on the left + right line width, plus a little padding.

--- a/lua/entities/offset_hoverball/cl_init.lua
+++ b/lua/entities/offset_hoverball/cl_init.lua
@@ -157,11 +157,7 @@ local function UpdateHeaderGUI()
 	TableOHBInf.W, TableOHBInf.H = surface.GetTextSize(GetLongest(TableOHBInf, "Name"))
 end
 
---[[
-	This candles the updates of the GUI translations
-	It is automatically handled by `UpdateHeaderGUI`
-	It is also changed whenever the language changes
-]]
+-- Runs UpdateHeaderGUI when the game language changes.
 UpdateHeaderGUI()
 cvars.RemoveChangeCallback( LanguageGUI:GetName(), gsModes.."_language" )
 cvars.AddChangeCallback( LanguageGUI:GetName(), UpdateHeaderGUI, gsModes.."_language")

--- a/lua/entities/offset_hoverball/init.lua
+++ b/lua/entities/offset_hoverball/init.lua
@@ -19,12 +19,12 @@ function ENT:UpdateCollide()
 
 		-- Using PhysObj:EnableCollisions caused an issue with duped hoverballs falling through the world.
 		-- Also the wiki has red text and who am I to argue?
-		
+
 		-- Collides with world but not ents/props/players/etc
-		self:SetCollisionGroup(COLLISION_GROUP_WORLD) 
+		self:SetCollisionGroup(COLLISION_GROUP_WORLD)
 	else
 		-- Collides with everything except players and vehicles. The only one to work reliably during testing.
-		self:SetCollisionGroup(COLLISION_GROUP_WEAPON) 
+		self:SetCollisionGroup(COLLISION_GROUP_WEAPON)
 	end
 end
 
@@ -155,7 +155,7 @@ function ENT:Initialize()
 	self.down_input = 0
 	self.slip = 0                      -- Slippery mode is considered enabled if this is anything but 0.
 	self.minslipangle = 0.1
-	
+
 	local phys = self:GetPhysicsObject()
 	if (phys:IsValid()) then
 		phys:Wake() -- Starts calling `PhysicsUpdate`
@@ -164,10 +164,11 @@ function ENT:Initialize()
 	end
 
 	-- If wiremod is installed then add some wire inputs to our ball.
-	if WireLib then self.Inputs = WireLib.CreateInputs(self, {
-		"Enable", "Height", "Brake", "Force","Air resistance",
-		"Angular damping", "Hover damping", "Brake strength", "Slip", "Min slip angle"
-	}) end
+	if WireLib then
+		self.Inputs = WireLib.CreateInputs(self, {"Enable", "Set height", "Adjust height", "Brake",
+		"Force", "Air resistance", "Angular damping", "Hover damping", "Height adjust speed", "Brake strength",
+		"Slip", "Min slip angle"})
+	end
 end
 
 function ENT:PhysicsUpdate()
@@ -194,7 +195,7 @@ function ENT:PhysicsUpdate()
 	if smoothadjust ~= 0 then -- Smooth adjustment is +1/-1
 		self.hoverdistance = self.hoverdistance + smoothadjust * self.adjustspeed
 		self.hoverdistance = math.max(0.01, self.hoverdistance)
-		
+
 		-- Bit scuffed, but doesn't use an extra var
 		-- Quick-fix for adjusting height with brakes on removing the header.
 		if self.damping_actual == self.brakeresistance then
@@ -292,7 +293,7 @@ if WireLib then
 
 		if (not IsValid(self)) then return false end
 
-		if name == "Brake" then 
+		if name == "Brake" then
 			if not self.hoverenabled then return end -- Brakes won't react if hovering is disabled.
 
 			if (value >= 1 and self.hoverenabled) then
@@ -309,7 +310,7 @@ if WireLib then
 
 		elseif name == "Enable" then
 			self.hoverenabled = tobool(value)
-		
+
 			if self.hoverenabled then
 				self:UpdateHoverText()
 				self:PhysWake()
@@ -325,8 +326,25 @@ if WireLib then
 		-- Don't update vars if hover isn't enabled.
 		if not self.hoverenabled then return end
 
-		if name == "Height" then
+		if name == "Set height" then
 			if type(value) == "number" then	self:SetHoverDistance(value) end
+		
+		elseif name == "Adjust height" then
+		
+			-- Smoothly adjusts height up and down like the default hotkeys.
+			-- Positive values go up, negative down, and 0 does nothing.
+			if type(value) == "number" then
+				if value >= 1 then
+					self.up_input = 1
+					self.down_input = 0
+				elseif value <= -1 then
+					self.up_input = 0
+					self.down_input = -1
+				elseif value == 0 then
+					self.up_input = 0
+					self.down_input = 0
+				end
+			end
 
 		elseif name == "Force" then
 			if type(value) == "number" then self:SetHoverForce(value) end
@@ -340,6 +358,9 @@ if WireLib then
 		elseif name == "Hover damping" then
 			if type(value) == "number" then self.hovdamping = math.abs(value) end
 
+		elseif name == "Height adjust speed" then
+			if type(value) == "number" then self.adjustspeed = math.abs(value) end
+
 		elseif name == "Brake strength" then
 			if type(value) == "number" then
 				self.brakeresistance = math.abs(value)
@@ -352,21 +373,23 @@ if WireLib then
 					self.brakeresistance = value
 				end
 			end
-			
+
 		elseif name == "Slip" then
 			if type(value) == "number" then self.slip = math.abs(value) end
-			
+
 		elseif name == "Min slip angle" then
 			if type(value) == "number" then self.minslipangle = math.abs(value) end
 		end
-		
+
 		-- Update hover text after a value changes via wiremod input.
-		-- Don't overwrite the header if the brakes are already enabled.
+		-- Don't overwrite the header if the brakes were already enabled.
 		if self.damping_actual == self.brakeresistance then
 			self:UpdateHoverText(1)
 		else
 			self:UpdateHoverText()
 		end
+		
+		self:PhysicsUpdate()
 	end
 end
 
@@ -455,7 +478,7 @@ function ENT:PostEntityPaste(ply, ball, info)
 	end
 	ball:UpdateCollide()
 	ball:UpdateHoverText(self.start_on and "" or 2)
-	
+
 	-- We need to re-wire all our inputs as they were before we were duped.
 	-- Luckily wirelib has a function for this. Would be great if any of it was documented.
 	if WireLib then

--- a/lua/entities/offset_hoverball/init.lua
+++ b/lua/entities/offset_hoverball/init.lua
@@ -292,8 +292,8 @@ if WireLib then
 
 		if (not IsValid(self)) then return false end
 
-		if name == "Brake" then -- Brakes won't react if hovering is disabled.
-			if not self.hoverenabled then return end
+		if name == "Brake" then 
+			if not self.hoverenabled then return end -- Brakes won't react if hovering is disabled.
 
 			if (value >= 1 and self.hoverenabled) then
 				self.damping_actual = self.brakeresistance
@@ -320,11 +320,15 @@ if WireLib then
 			end
 			self:PhysicsUpdate()
 			return
+		end
 
-		elseif name == "Height" then
-			if type(value) == "number" then self:SetHoverDistance(value) end
+		-- Don't update vars if hover isn't enabled.
+		if not self.hoverenabled then return end
 
-		elseif name == "Force" then -- Clamped to prevent physics crash.
+		if name == "Height" then
+			if type(value) == "number" then	self:SetHoverDistance(value) end
+
+		elseif name == "Force" then
 			if type(value) == "number" then self:SetHoverForce(value) end
 
 		elseif name == "Air resistance" then
@@ -354,6 +358,14 @@ if WireLib then
 			
 		elseif name == "Min slip angle" then
 			if type(value) == "number" then self.minslipangle = math.abs(value) end
+		end
+		
+		-- Update hover text after a value changes via wiremod input.
+		-- Don't overwrite the header if the brakes are already enabled.
+		if self.damping_actual == self.brakeresistance then
+			self:UpdateHoverText(1)
+		else
+			self:UpdateHoverText()
 		end
 	end
 end

--- a/lua/entities/offset_hoverball/init.lua
+++ b/lua/entities/offset_hoverball/init.lua
@@ -350,7 +350,12 @@ if WireLib then
 			if type(value) == "number" then self:SetHoverForce(value) end
 
 		elseif name == "Air resistance" then
-			if type(value) == "number" then self.damping = math.abs(value) end
+			if type(value) == "number" then
+			
+				-- Update immediately unless the brakes are on, in which case it will update when they're next off.
+				self.damping = math.abs(value)
+				if self.damping_actual ~= self.brakeresistance then self.damping_actual = self.damping end
+			end
 
 		elseif name == "Angular damping" then
 			if type(value) == "number" then self.rotdamping = math.abs(value) end

--- a/lua/entities/offset_hoverball/shared.lua
+++ b/lua/entities/offset_hoverball/shared.lua
@@ -21,10 +21,10 @@ function ENT:GetTrace(origin, length, output)
 	return tr
 end
 
-function ENT:SetHoverForce(arg) -- Fix physics crash
+function ENT:SetHoverForce(arg)
 	self.hoverforce = math.Clamp(math.abs(tonumber(arg) or 0), 0, 999999)
 end
 
-function ENT:SetHoverDistance(arg) -- Fix physics crash
+function ENT:SetHoverDistance(arg)
 	self.hoverdistance = math.Clamp(math.abs(tonumber(arg) or 0), 0, 999999)
 end


### PR DESCRIPTION
- Hover UI now updates correctly when values are changed via wiremod.
- Changed wire input "Height" to "Set height".
- Added "Adjust height" input that emulates pressing the hotkeys.
- Added "Height adjust speed" wire input.
- Fixed "Air resistance" wire input not updating correctly. _(Drift button, woo)_
- Fixed wire inputs being able to update while hover is disabled.
- Fixed changing wiremod inputs removing the 'Brakes enabled' header.
- Removed trailing space in some files.