### PR TITLE
cl_init.lua refactor + code optimisation

### DIFF
--- a/lua/entities/offset_hoverball/cl_init.lua
+++ b/lua/entities/offset_hoverball/cl_init.lua
@@ -1,7 +1,8 @@
 include("shared.lua")
 
-local gsModes = "offset_hoverball"
-local gsClass = "offset_hoverball"
+local gsModes = "offset_hoverball" 	-- Name of tool, for concommands, etc.
+local gsClass = "offset_hoverball"	-- Name of OHB entity, for checking when to draw the UI.
+
 local ToolMode = GetConVar("gmod_toolmode")
 local ShouldRenderLasers = GetConVar(gsModes.."_showlasers")
 local AlwaysRenderLasers = GetConVar(gsModes.."_alwaysshowlasers")
@@ -47,15 +48,16 @@ surface.CreateFont("OHBTipFontSmall", {
 	extended = true
 })
 
--- UI colours:
-local CoOHBName 	= Color(200, 200, 200)
-local CoOHBValue 	= Color(80, 220, 80)
-local CoOHBBack20 	= Color(20, 20, 20)
-local CoOHBBack60 	= Color(60, 60, 60)
-local CoOHBBack70 	= Color(70, 70, 70)
+-- UI colours
+local CoOHBName 	= Color(200, 200, 200)		-- Text colour.
+local CoOHBValue 	= Color(80, 220, 80)		-- Right-size text.
+local CoOHBBack20 	= Color(20, 20, 20)		-- Window outline.
+local CoOHBBack60 	= Color(60, 60, 60)		-- Main background + pointy thing bg.
+local CoOHBBack70 	= Color(65, 65, 65)		-- Header background.
+local CoMidArrow 	= Color(100,100,100,255)	-- Little arrow colour.
+local CoHeaderPulse = Color(255,200,0,255)		-- Colour of the text pulse effect.
+
 local CoLaserBeam 	= Color(100, 100, 255)
-local CoHeaderPulse = Color(255,200,0,255)
-local CoMidArrow 	= Color(100,100,100,255)
 
 local TableDrPoly = {
 	{x = 0, y = 0},
@@ -80,10 +82,8 @@ local MouseoverUI_HeaderKeys = {
 }
 
 
---[[
-	Various network messages that transfer values server > client
-	These are used to initialize certain values on the client
-]]
+-- Various network messages that transfer values server > client
+-- These are used to initialize certain values on the client
 net.Receive(gsModes.."SendUpdateMask", function(len, ply)
 	local ball, mask = net.ReadEntity(), net.ReadUInt(32)
 	if(ball and ball:IsValid()) then ball.mask = mask end
@@ -151,6 +151,8 @@ function ENT:DrawInfoTitle(StrT, PosX, PosY, SizX, SizY)
 
 	draw.RoundedBoxEx(8, PosX, PosY, SizX, SizY, CoOHBBack20, true, true, false, false) 		-- Header Outline
 	draw.RoundedBoxEx(8, PosX+1, PosY+1, SizX-2, SizY, CoOHBBack70, true, true, false, false) 	-- Header BG
+
+	draw.DrawText(StrT, "OHBTipFont", TxtX+1, TxtY-10, color_black, TEXT_ALIGN_CENTER)
 	draw.SimpleText(StrT, "OHBTipFontGlow", TxtX, TxtY, CoHeaderPulse, TEXT_ALIGN_CENTER, TEXT_ALIGN_CENTER)
 	local TW, _ = draw.SimpleText(StrT, "OHBTipFont", TxtX, TxtY, CoOHBName, TEXT_ALIGN_CENTER, TEXT_ALIGN_CENTER)
 	
@@ -175,12 +177,19 @@ function ENT:DrawInfoContent(HBData, PosX, PosY, SizX, PadX, PadY, PadMid)
 
 	for K,V in pairs(MouseoverUI_LabelKeys) do
 		local hbx, hvx = (PosX + PadX), (PosX + (SizX - PadX))
+		local FormattedNum = DecFormat:format(HBData[K])
+
+		-- Add slightly off-center text as a shadow to make the foreground text more readable.
+		draw.DrawText(V, Font, hbx+1, RowY-9, color_black, TEXT_ALIGN_LEFT, TEXT_ALIGN_CENTER)
 
 		-- Get string len from left and right side, add them together and return that so we can adjust the size of the panel.
 		local StrW1, StrH = draw.SimpleText(V, Font, hbx, RowY, CoOHBName, TEXT_ALIGN_LEFT, TEXT_ALIGN_CENTER)
 		LongestL = math.max(LongestL, StrW1)
 		
-		local StrW2, _ = draw.SimpleText(DecFormat:format(HBData[K]), Font, hvx, RowY, CoOHBValue, TEXT_ALIGN_RIGHT, TEXT_ALIGN_CENTER)
+		-- Right-side text shadow.
+		draw.DrawText(FormattedNum, Font, hvx+1, RowY-9, color_black, TEXT_ALIGN_RIGHT)
+
+		local StrW2, _ = draw.SimpleText(FormattedNum, Font, hvx, RowY, CoOHBValue, TEXT_ALIGN_RIGHT, TEXT_ALIGN_CENTER)
 		LongestR = math.max(LongestR, StrW2)
 		
 		RowY = RowY + (StrH + PadY)

--- a/lua/entities/offset_hoverball/cl_init.lua
+++ b/lua/entities/offset_hoverball/cl_init.lua
@@ -3,7 +3,6 @@ include("shared.lua")
 local gsModes = "offset_hoverball"
 local gsClass = "offset_hoverball"
 local ToolMode = GetConVar("gmod_toolmode")
-local LanguageGUI = GetConVar("gmod_language")
 local ShouldRenderLasers = GetConVar(gsModes.."_showlasers")
 local AlwaysRenderLasers = GetConVar(gsModes.."_alwaysshowlasers")
 local ShouldRenderDecimals = GetConVar(gsModes.."_showdecimals")
@@ -48,119 +47,38 @@ surface.CreateFont("OHBTipFontSmall", {
 	extended = true
 })
 
-local CoOHBName = Color(200, 200, 200)
-local CoOHBValue = Color(80, 220, 80)
-local CoOHBBack20 = Color(20, 20, 20)
-local CoOHBBack60 = Color(60, 60, 60)
-local CoOHBBack70 = Color(70, 70, 70)
-local CoLaserBeam = Color(100, 100, 255)
-local CoPulseMode = Color(0, 0, 0, 200)
+-- UI colours:
+local CoOHBName 	= Color(200, 200, 200)
+local CoOHBValue 	= Color(80, 220, 80)
+local CoOHBBack20 	= Color(20, 20, 20)
+local CoOHBBack60 	= Color(60, 60, 60)
+local CoOHBBack70 	= Color(70, 70, 70)
+local CoLaserBeam 	= Color(100, 100, 255)
+local CoHeaderPulse = Color(255,200,0,255)
+local CoMidArrow 	= Color(100,100,100,255)
 
 local TableDrPoly = {
 	{x = 0, y = 0},
 	{x = 0, y = 0},
 	{x = 0, y = 0}
-}; TableDrPoly.Size = #TableDrPoly
+}
 
-local TableOHBInf = {
-	{ID = 2, Hash = "tool."..gsModes..".height"          , Name = ""},
-	{ID = 3, Hash = "tool."..gsModes..".force"           , Name = ""},
-	{ID = 4, Hash = "tool."..gsModes..".air_resistance"  , Name = ""},
-	{ID = 5, Hash = "tool."..gsModes..".angular_damping" , Name = ""},
-	{ID = 6, Hash = "tool."..gsModes..".hover_damping"   , Name = ""},
-	{ID = 7, Hash = "tool."..gsModes..".brake_resistance", Name = ""}
-}; TableOHBInf.Size = #TableOHBInf
+-- Translation keys for the hover UI labels. Index starts at 2 because 1 is the header.
+local MouseoverUI_LabelKeys = {
+	[2] = "#tool."..gsModes..".height",
+	[3] = "#tool."..gsModes..".force",
+	[4] = "#tool."..gsModes..".air_resistance",
+	[5] = "#tool."..gsModes..".angular_damping",
+	[6] = "#tool."..gsModes..".hover_damping",
+	[7] = "#tool."..gsModes..".brake_resistance"
+}
 
-local HeaderStr = {
-	{ID = 1, Hash = "status."..gsModes..".brake_enabled" , Name = ""},
-	{ID = 2, Hash = "status."..gsModes..".hover_disabled", Name = ""}
-}; HeaderStr.Size = #HeaderStr
+-- Same deal for the header keys, but normal indexing on these ones.
+local MouseoverUI_HeaderKeys = {
+	[1] = "#status."..gsModes..".brake_enabled",
+	[2] = "#status."..gsModes..".hover_disabled"
+}
 
-local function GetTextSizeX(font, text)
-	if(font) then surface.SetFont(font) end
-	return select(1,surface.GetTextSize(text or "X"))
-end
-
---[[
-	* Helper function for `GetLongest` that records longest string
-	* It will do the `GetLongest`'s internal logic accordingly
-	* We should update `GetCurrent` to change the logic in the future
-	* str > String we check
-	* mxv > Max value being checked
-	* mxn > Max length being checked
-	* act > Process custom routine ( when available )
-	* tab > The table being checked
-	* idx > Index for table rows/columns
-	* row > Table row passed when we have 2D array
-	* key > Key under which resides the end-value
-]]
-local function GetCurrent(str, mxv, mxn, act, tab, idx, row, key)
-	local mxv, mxn, str = mxv, mxn, str
-	if(act) then -- Custom routine is available
-		local suc, out = pcall(act, tab, idx, row, key, str)
-		if(not suc) then error("Current["..idx.."]["..str.."]: "..out) end
-		str = out -- Successfully processed custom routine
-	end
-	local sen = str:len() -- Current entry length
-	if sen > mxn or not mxv then -- Longer or not available yet
-		mxv, mxn = str, sen -- Initialize the current longest
-	end -- Return the longest length and longest string
-	return mxv, mxn
-end
-
---[[
-	* Retrieves the longest string from a table
-	* str > String we check
-	* mxv > Max value being checked
-	* mxn > Max length being checked
-	* tab > The table being checked
-	* key > Key under which resides the end-value
-	* sri > Start index for the loop
-	* eni > End index for the loop
-	* act > Process custom routine ( when available )
-]]
-local function GetLongest(tab, key, sri, eni, act)
-	local sri, mxn, mxv = (sri or 1), 0
-	local eni = ((eni or tab.Size) or 0)
-	if key ~= nil then
-		for idx = sri, eni do
-			local row = tab[idx]
-			local str = row[key] -- Process current value and compare
-			mxv, mxn = GetCurrent(str, mxv, mxn, act, tab, idx, row, key)
-		end
-	else
-		for idx = sri, eni do
-			local str = tab[idx] -- Process current value and compare
-			mxv, mxn = GetCurrent(str, mxv, mxn, act, tab, idx)
-		end
-	end -- Return only the string here or the second argument will be unpacked
-	return mxv -- The second argument will be passed to `surface.GetTextSize`
-end
-
-local function UpdateHeaderGUI()
-	-- Always append a colon when missing
-	for i = 1, TableOHBInf.Size do -- For all the rows
-		local row = TableOHBInf[i] -- Manipulate row
-		local str = language.GetPhrase(row.Hash) -- Lang
-		row.Name = str:sub(-1,-1) == ":" and str or str..":"
-	end -- Translation is added with a colon
-	for i = 1, HeaderStr.Size do -- For all headers
-		local row = HeaderStr[i] -- Read header row
-		row.Name = language.GetPhrase(row.Hash)
-	end -- Translate all the headers according to the hash
-	-- Grab text size width the longest text on left of UI. (Will vary per language)
-	-- Also cache font height while here so we're not looking it up every frame.
-	surface.SetFont("OHBTipFont")
-	HeaderStr.W, HeaderStr.H = surface.GetTextSize(GetLongest(HeaderStr, "Name"))
-	HeaderStr.W, HeaderStr.H = HeaderStr.W + 0, HeaderStr.H + 6 -- Adjust header
-	surface.SetFont("OHBTipFontSmall")
-	TableOHBInf.W, TableOHBInf.H = surface.GetTextSize(GetLongest(TableOHBInf, "Name"))
-end
-
--- Runs UpdateHeaderGUI when the game language changes.
-UpdateHeaderGUI()
-cvars.RemoveChangeCallback( LanguageGUI:GetName(), gsModes.."_language" )
-cvars.AddChangeCallback( LanguageGUI:GetName(), UpdateHeaderGUI, gsModes.."_language")
 
 --[[
 	Various network messages that transfer values server > client
@@ -186,15 +104,6 @@ net.Receive(gsModes.."SendUpdateFilter", function(len, ply)
 	end
 end)
 
-local function GetPulseColor()
-	local tim = 2.5 * CurTime()
-	local frc = tim - math.floor(tim)
-	local mco = math.abs(2 * (frc - 0.5))
-	local com = math.Clamp(mco, 0.1, 1)
-	CoPulseMode.r = com * 255
-	CoPulseMode.g = com * 200
-	return CoPulseMode
-end
 
 function ENT:DrawTablePolygon(co, x1, y1, x2, y2, x3, y3)
 	TableDrPoly[1].x = x1; TableDrPoly[1].y = y1
@@ -205,8 +114,9 @@ function ENT:DrawTablePolygon(co, x1, y1, x2, y2, x3, y3)
 	surface.DrawPoly(TableDrPoly)
 end
 
+
+-- Draws the pointy arrow using DrawTablePolygon()
 function ENT:DrawInfoPointy(PosX, PosY, SizX, SizY)
-	-- Base functionality for drawing the pointy arrow. Please adjust the API calls only
 	local x1, y1 = PosX, PosY+SizY/2    -- Triangle pointy point
 	local x2, y2 = PosX+SizX, PosY      -- Triangle top point
 	local x3, y3 = PosX+SizX, PosY+SizY -- Triangle bottom point
@@ -214,38 +124,73 @@ function ENT:DrawInfoPointy(PosX, PosY, SizX, SizY)
 	self:DrawTablePolygon(CoOHBBack60, x1+3, y1, x2, y2+2, x3, y3-2) -- Background
 end
 
-function ENT:DrawInfoBox(PosX, PosY, SizX, SizY)
-	-- Base functionality for drawing the box container. Please adjust the API calls only
-	draw.RoundedBox(8, PosX  , PosY  , SizX  , SizY  , CoOHBBack20) -- Back box (black)
-	draw.RoundedBox(8, PosX+1, PosY+1, SizX-2, SizY-2, CoOHBBack60) -- Data box (Grey)
+
+-- Base functionality for drawing the box container.
+function ENT:DrawInfoBox(PosX, PosY, SizX, SizY, TopCorners)
+	draw.RoundedBoxEx(8, PosX  , PosY  , SizX  , SizY  , CoOHBBack20, TopCorners, TopCorners, true, true) -- Outline (Black)
+	draw.RoundedBoxEx(8, PosX+1, PosY+1, SizX-2, SizY-2, CoOHBBack60, TopCorners, TopCorners, true, true) -- Inner background (Grey)
 end
 
+
+local function SineBetween(from, to, speed)
+    return math.Clamp(math.Remap(math.sin(CurTime()*speed)+0.005, -1, 1, from, to), from, to)
+end
+
+
+-- Draws the flashing title on the top of the mouseover UI. Is only called if there is actually a title.
 function ENT:DrawInfoTitle(StrT, PosX, PosY, SizX, SizY)
-	local TxtX, TxtY = (PosX + (SizX / 2)), (PosY + 17)
-	local CoDyn, StrT = GetPulseColor(), tostring(StrT)
-	-- Base functionality for drawing the title. Please adjust the API calls only
-	draw.RoundedBoxEx(8, PosX, PosY, SizX, SizY, CoOHBBack20, true, true, false, false) -- Header Outline
-	draw.RoundedBoxEx(8, PosX+1, PosY+1, SizX-2, SizY, CoOHBBack70, true, true, false, false) -- Header BG
-	draw.SimpleText(StrT, "OHBTipFontGlow", TxtX, TxtY, CoDyn, TEXT_ALIGN_CENTER, TEXT_ALIGN_CENTER)
-	draw.SimpleText(StrT, "OHBTipFont", TxtX, TxtY, CoOHBName, TEXT_ALIGN_CENTER, TEXT_ALIGN_CENTER)
+	local TxtX 	= (PosX + (SizX / 2))
+	local TxtY 	= (PosY-12)
+	local StrT 	= tostring(StrT)
+
+	-- Tweak position of background box.
+	PosY = PosY-30
+	SizY = SizY-8
+
+	CoHeaderPulse.a = SineBetween(0, 255, 5)
+
+	draw.RoundedBoxEx(8, PosX, PosY, SizX, SizY, CoOHBBack20, true, true, false, false) 		-- Header Outline
+	draw.RoundedBoxEx(8, PosX+1, PosY+1, SizX-2, SizY, CoOHBBack70, true, true, false, false) 	-- Header BG
+	draw.SimpleText(StrT, "OHBTipFontGlow", TxtX, TxtY, CoHeaderPulse, TEXT_ALIGN_CENTER, TEXT_ALIGN_CENTER)
+	local TW, _ = draw.SimpleText(StrT, "OHBTipFont", TxtX, TxtY, CoOHBName, TEXT_ALIGN_CENTER, TEXT_ALIGN_CENTER)
+	
+	return TW
 end
 
-function ENT:DrawInfoContent(TData, PosX, PosY, SizX, PadX, PadY)
-	local Font = "OHBTipFontSmall" 	-- Localize font name
-	local TxtY = TableOHBInf.H + PadY 	-- Use cached font width here
 
-	-- Loop through TableOHBInf for labels and draw values from TData:
-	for di = 1, TableOHBInf.Size do
-		local inf = TableOHBInf[di]
-		local idx, txt = inf.ID, inf.Name
+-- Draws little arrows in the middle of the left and right text.
+function ENT:DrawMidArrows(PosX, PosY, PadY)
+	for K,V in pairs(MouseoverUI_LabelKeys) do
+		draw.SimpleText("▸", Font, PosX, PosY, CoMidArrow, TEXT_ALIGN_CENTER, TEXT_ALIGN_CENTER)
+		PosY = PosY + (20 + PadY)
+	end	
+end
 
-		local hby = PosY + ((di - 1) * TxtY)
+
+-- Draws the rows of text for the mouseover UI. Turns out draw.SimpleText supports translating strings and checking text width.
+function ENT:DrawInfoContent(HBData, PosX, PosY, SizX, PadX, PadY, PadMid)
+	local Font = "OHBTipFontSmall"
+	local RowY = PosY
+	local LongestL, LongestR = 0, 0
+
+	for K,V in pairs(MouseoverUI_LabelKeys) do
 		local hbx, hvx = (PosX + PadX), (PosX + (SizX - PadX))
 
-		draw.SimpleText(txt, Font, hbx, hby, CoOHBName, TEXT_ALIGN_LEFT, TEXT_ALIGN_CENTER)
-		draw.SimpleText(TData[idx], Font, hvx, hby, CoOHBValue, TEXT_ALIGN_RIGHT, TEXT_ALIGN_CENTER)
+		-- Get string len from left and right side, add them together and return that so we can adjust the size of the panel.
+		local StrW1, StrH = draw.SimpleText(V, Font, hbx, RowY, CoOHBName, TEXT_ALIGN_LEFT, TEXT_ALIGN_CENTER)
+		LongestL = math.max(LongestL, StrW1)
+		
+		local StrW2, _ = draw.SimpleText(DecFormat:format(HBData[K]), Font, hvx, RowY, CoOHBValue, TEXT_ALIGN_RIGHT, TEXT_ALIGN_CENTER)
+		LongestR = math.max(LongestR, StrW2)
+		
+		RowY = RowY + (StrH + PadY)
 	end
+
+	self:DrawMidArrows(PosX+LongestL+(PadMid/2), PosY, PadY)
+
+	return (LongestL+LongestR)
 end
+
 
 function ENT:DrawLaser()
 	if not IsValid(self) then return end
@@ -255,10 +200,12 @@ function ENT:DrawLaser()
 		(OwnWeapon and OwnWeapon:IsValid() and
 		ToolMode:GetString() == gsModes and
 		OwnWeapon:GetClass() == "gmod_tool")
-	then -- Draw the hoverball lasers
+	then 
+	
+		-- Draw the hoverball lasers
 		local hbpos = self:WorldSpaceCenter()
 		local tr = self:GetTrace(hbpos, -500)
-		-- When the trace hits make 3D rendering contest and draw laser
+		-- When the trace hits make 3D rendering context and draw laser
 		if tr.Hit then
 			cam.Start3D()
 				render.SetMaterial(laser)
@@ -271,6 +218,10 @@ function ENT:DrawLaser()
 	end
 end
 
+
+local UIContainerWidth = 200
+
+-- Draw the UI that appears when you look at a hoverball.
 hook.Add("HUDPaint", "OffsetHoverballs_MouseoverUI", function()
 	local OwnPlayer = LocalPlayer()
 	local LookingAt = OwnPlayer:GetEyeTrace().Entity
@@ -287,55 +238,46 @@ hook.Add("HUDPaint", "OffsetHoverballs_MouseoverUI", function()
 	if not TipNW or TipNW == "" then return end
 
 	local HBData = TipNW:Split(",")
-	local SW, SH, CN = ScrW(), ScrH(), TableOHBInf.Size
-
-	-- Vars that control how we draw the mouse over UI:
 
 	-- Adjusts position of the UI, including all components. (Polygon, text, etc)
-	local BoxX = (SW / 2) + 60
-	local BoxY = (SH / 2) - 80
+	local BoxX = (ScrW() / 2) + 60
+	local BoxY = (ScrH() / 2) - 80
 
 	-- Text padding:
-	local PadX = 10	-- Moves text inwards, away from walls.
-	local PadY = 2	-- Spacing above/below each text line.
-
-	-- Box width, must be wide enough to fit everything.
-	local SizeX = 200
+	local PadX = 10		-- Moves text inwards, away from walls.
+	local PadY = 2		-- Spacing above/below each text line.
+	local PadMid = 50 	-- Space between left and right text.
+	
 	-- Box height, scales with 'PadY' text padding.
-	local SizeY = CN * TableOHBInf.H + (CN - 1) * PadY + PadX
+	local SizeY = 140 + (PadY*2)
+	
 	-- Scaling multiplier for the little pointer arrow thing.
 	local SizeP = 25
+	
 	-- X draw coordinate for the pointy triangle.
 	local PoinX = HBPos:ToScreen().y - SizeP * 0.5
 
-	-- This code should support resizing the box to any value, as well as any language for the left labels.
-	-- The box should grow dynamically in order to be able to contain all the labels and values.
-	-- Width of the box longest on the left + right line width, plus a little padding.
-	SizeX = TableOHBInf.W + 30 + GetTextSizeX("OHBTipFontSmall",
-		GetLongest(TableOHBInf, nil, nil, nil, -- Process and get the longest
-			function(t, i, r, k, v) -- For each parameter being displayed run routine
-				local idx = t[i].ID -- Obtain the source data index to read the value
-				local str = DecFormat:format(HBData[idx]) -- Format decimals
-				HBData[idx] = str; return str -- Return the string being compared
-			end))
+	-- Check to see if we will be drawing a header.
+	local IsDrawingHeader = false
+	if HBData[1] ~= "" then IsDrawingHeader = true end
 
-	if HBData[1] ~= "" then
-		-- Convert and calculate header translation index:
-		local idx = (tonumber(HBData[1]) or 0)
-		-- Support for headers with spaces
-		if(idx > 0 and HeaderStr[idx]) then
-			-- Overlay first argument is present, draw with header:
-			LookingAt:DrawInfoBox(BoxX, BoxY+22, SizeX, SizeY+10)
-			LookingAt:DrawInfoPointy(BoxX-SizeP+1, math.Clamp(PoinX, BoxY+30, BoxY+SizeY), SizeP, SizeP)
-			LookingAt:DrawInfoTitle(HeaderStr[idx].Name, BoxX, BoxY, SizeX, HeaderStr.H)
-			LookingAt:DrawInfoContent(HBData, BoxX, BoxY+45, SizeX, PadX, PadY)
-		end
-	else
-		-- Draw contents without header:
-		LookingAt:DrawInfoBox(BoxX, BoxY, SizeX, SizeY)
-		LookingAt:DrawInfoPointy(BoxX-SizeP+1, math.Clamp(PoinX, BoxY+10, BoxY+SizeY-32), SizeP, SizeP)
-		LookingAt:DrawInfoContent(HBData, BoxX, BoxY+15, SizeX, PadX, PadY)
+	-- Draw the background and little pointy arrow thing.
+	LookingAt:DrawInfoBox(BoxX, BoxY, UIContainerWidth, SizeY, !IsDrawingHeader)
+	LookingAt:DrawInfoPointy(BoxX-SizeP+1, math.Clamp(PoinX, BoxY+10, BoxY+SizeY-32), SizeP, SizeP)
+	
+	local WidthContent = 100
+	local WidthHeader = 100
+	
+	-- Draws the info rows and returns the total width of the widest one.
+	WidthContent = LookingAt:DrawInfoContent(HBData, BoxX, BoxY+17, UIContainerWidth, PadX, PadY, PadMid)
+	
+	-- Draw header.
+	if IsDrawingHeader then
+		WidthHeader = LookingAt:DrawInfoTitle(MouseoverUI_HeaderKeys[tonumber(HBData[1]) or 0], BoxX, BoxY, UIContainerWidth, 40)
 	end
+	
+	-- Container width updates 1 frame behind, hopefully it shouldn't be too noticable.
+	UIContainerWidth = math.max(WidthContent, WidthHeader) + PadMid
 end)
 
 function ENT:Draw()


### PR DESCRIPTION
### cl_init.lua code refactor:
Did a bit of tinkering with the last PR and discovered a way to do what we were doing with about half the amount of functions.

Turns out that draw.SimpleText supports translating strings from the .properties file and updates automatically when the game language changes.
It also returns the width and height of whatever text it is drawing, so we can use that to calc the width of the UI without having to re-check things with surface.GetTextSize every time we translate a string.

### Other changes in this version:
- Added some little triangles to the UI, to help in distinguishing rows as well as filling some blank space.
- Added a modified sine wave function for making the header text pulse, seemed to have the same performance impact as GetPulseColor() during testing.
- Added shadows to the UI text to add contrast and slightly increase readability.
- Added code comments and tweaked layout to hopefully make things clearer and more maintainable.,